### PR TITLE
Keyboard: change the default pgup/pgdown behavior

### DIFF
--- a/src/components/keyboard/keyboard.js
+++ b/src/components/keyboard/keyboard.js
@@ -123,7 +123,7 @@ export default {
     keyboard: {
       enabled: false,
       onlyInViewport: true,
-      pageUpDown: true,
+      pageUpDown: false,
     },
   },
   create() {


### PR DESCRIPTION
Currently, Swiper will grab pageup/pagedn keyboard presses along with
left/right arrow keys. This is a problem, as described in https://github.com/Automattic/jetpack/issues/14567. In
particular, it is an accessibility problem, as someone who cannot use
a mouse (for example due to a disability) will be using pageup/pagedn
to navigate a page, and once they reach the Swiper slideshow block they
can no longer continue navigating without using a mouse to click out of
the slideshow. Even attempting to tab out of Swiper doesn't work reliably,
once trapped in it.

This changes the default to not grab pageup/pagedn key presses. Users
can still use the arrow keys to go forward and back in the slideshow.
